### PR TITLE
Add (unsupported) MRT type 5

### DIFF
--- a/lib/mrt/parsebgp_mrt.h
+++ b/lib/mrt/parsebgp_mrt.h
@@ -288,6 +288,9 @@ typedef struct parsebgp_mrt_bgp4mp {
 
 typedef enum {
 
+  /** 5    UNKNOWN ("MRTD") */
+  PARSEBGP_MRT_TYPE_5 = 5,
+
   /** 11   OSPFv2 */
   PARSEBGP_MRT_TYPE_OSPF_V2 = 11,
 


### PR DESCRIPTION
This is present in really old RIS data, and apparently even bgpdump does not support this. I can't seem to find any documentation online about this format. I took a quick look at the raw message data and it didn't appear to be a BGP message (no 16-byte marker at least).