### PR TITLE
Fix bug when iterating through path attributes

### DIFF
--- a/lib/bgp/parsebgp_bgp_update.c
+++ b/lib/bgp/parsebgp_bgp_update.c
@@ -521,7 +521,7 @@ parsebgp_error_t parsebgp_bgp_update_path_attrs_decode(
   }
 
   // read until we run out of attributes
-  while (nread < path_attrs->len) {
+  while ((nread - sizeof(path_attrs->len)) < path_attrs->len) {
 
     // Attribute Flags
     PARSEBGP_DESERIALIZE_VAL(buf, len, nread, flags_tmp);


### PR DESCRIPTION
We were previously reading path attributes while `nread` was less than the total length of the path attributes data. The problem here is that `nread` is set to 2 at the start of iteration due to reading the `uint16_t` length field. The length field does not include itself in the length value, so halting iteration at `nread == path_attrs->len` was incorrect.

Thanks to @ojasgupta for helping validate this fix.