### PR TITLE
Better handling of corrupted TABLE_DUMP messages

### DIFF
--- a/lib/mrt/parsebgp_mrt.c
+++ b/lib/mrt/parsebgp_mrt.c
@@ -988,7 +988,30 @@ parsebgp_error_t parsebgp_mrt_decode(parsebgp_opts_t *opts,
   }
   nread += slen;
 
-  assert(MRT_HDR_LEN + msg->len == nread);
+  if ((MRT_HDR_LEN + msg->len) > nread) {
+    // reported message length is too long.
+    //
+    // we have two options: believe the reported message length, skip over the
+    // trailing junk and keep reading, or trust that we have read the message
+    // correctly and it is the message length itself that is wrong, so we just
+    // keep reading from where we are now.
+    //
+    // chances are that neither of these options will work and we should just
+    // stop parsing now. but if the user has decided they want to struggle on in
+    // the face of invalid data, then we need to pick one.
+    //
+    // let's say that it is more likely that the MRT encoder is wrong than the
+    // BGP encoder, so we ignore the MRT message length, and just keep
+    // reading. (this also happens to be what happened in the one example i have
+    // seen of this -- although in that case the next message was even more
+    // corrupt.)
+    PARSEBGP_SKIP_INVALID_MSG(opts, buf, nread, 0,
+                              "Unexpected end of MRT message. "
+                              "Expected %d bytes, found %d",
+                              (int)msg->len + MRT_HDR_LEN, (int)nread);
+  } else {
+    assert(MRT_HDR_LEN + msg->len == nread);
+  }
 
   *len = nread;
   return PARSEBGP_OK;


### PR DESCRIPTION
Previously we had an `assert` in place to ensure that the number of bytes parsed from a TABLE_DUMP message was the same as the length reported in the MRT header. It seems however that there are corrupted data files where the reported length is longer than the actual data. This commit changes the assert to the standard invalid message macro in this case (it leaves the assert for the case where the number of bytes read is *more* than the reported message length, though this could possibly cause a similar problem).

See the inline comments about how I decided to try and skip over the remainder of the message if the user has asked to struggle on in the face of invalid data.