### PR TITLE
Add parentheses to data field in dump macro

### DIFF
--- a/lib/parsebgp_utils.h
+++ b/lib/parsebgp_utils.h
@@ -180,7 +180,7 @@
         if (_byte != 0) {                                                      \
           printf(" ");                                                         \
         }                                                                      \
-        printf("%02X", data[_byte]);                                           \
+        printf("%02X", (data)[_byte]);                                         \
       }                                                                        \
       printf("\n");                                                            \
     }                                                                          \


### PR DESCRIPTION
This allows the data parameter to be passed as an expression (e.g., `buf+nread`).