### PR TITLE
Improve handling of truncated BGP messages

### DIFF
--- a/lib/parsebgp_error.c
+++ b/lib/parsebgp_error.c
@@ -28,16 +28,17 @@
 #include <stdlib.h>
 
 char *err_strings[] = {
-  "No Error",        // PARSEBGP_OK
-  "Partial Message", // PARSEBGP_PARTIAL_MSG
-  "Invalid Message", // PARSEBGP_INVALID_MSG
-  "Not Implemented", // PARSEBGP_NOT_IMPLEMENTED
-  "Malloc Failure",  // PARSEBGP_MALLOC_FAILURE
+  "No Error",           // PARSEBGP_OK
+  "Partial Message",    // PARSEBGP_PARTIAL_MSG
+  "Invalid Message",    // PARSEBGP_INVALID_MSG
+  "Not Implemented",    // PARSEBGP_NOT_IMPLEMENTED
+  "Malloc Failure",     // PARSEBGP_MALLOC_FAILURE
+  "Truncated Message",  // PARSEBGP_TRUNCATED_MSG
 };
 
 const char *parsebgp_strerror(parsebgp_error_t err)
 {
-  if (err > 0 || err < PARSEBGP_MALLOC_FAILURE) {
+  if (err > 0 || err <= PARSEBGP_N_ERR) {
     return "Unknown Error";
   }
   return err_strings[abs(err)];

--- a/lib/parsebgp_error.h
+++ b/lib/parsebgp_error.h
@@ -50,6 +50,11 @@ typedef enum parsebgp_error {
   /** Memory allocation failure */
   PARSEBGP_MALLOC_FAILURE = -4,
 
+  /** Message does not contain an entire sub-message */
+  PARSEBGP_TRUNCATED_MSG = -5,
+
+  PARSEBGP_N_ERR = -6,
+
 } parsebgp_error_t;
 
 /**

--- a/tools/parsebgp.c
+++ b/tools/parsebgp.c
@@ -126,6 +126,15 @@ static int parse(parsebgp_opts_t *opts, parsebgp_msg_type_t type, char *fname)
           // refill the buffer and try again
           parsebgp_clear_msg(msg);
           break;
+        } else if (err == PARSEBGP_TRUNCATED_MSG && opts->ignore_invalid) {
+          if (!(opts)->silence_invalid) {
+            fprintf(stderr, "WARN: truncated message %" PRIu64 " in %s\n",
+              cnt, fname);
+          }
+          ptr += dec_len;
+          remain -= dec_len;
+          cnt++;
+          continue;
         }
         // else: its a fatal error
         fprintf(stderr, "ERROR: Failed to parse message (%d:%s)\n", err,


### PR DESCRIPTION
parsebgp_mrt_decode() returns the new error code PARSEBGP_TRUNCATED_MSG
instead of PARSEBGP_INVALID_MSG, and updates the decoded length, when an MRT
mesage is too short to contain a full BGP message, giving the caller the
option to continue with the next MRT message.

tools/parsebgp takes advantage of this according to its -i option.

(Example case: routeviews.route-views2.updates.1212316500)