### PR TITLE
Fix core in parsebgp_bgp_open_clear()

### DIFF
--- a/lib/bgp/parsebgp_bgp_notification.c
+++ b/lib/bgp/parsebgp_bgp_notification.c
@@ -72,6 +72,10 @@ void parsebgp_bgp_notification_destroy(parsebgp_bgp_notification_t *msg)
 
 void parsebgp_bgp_notification_clear(parsebgp_bgp_notification_t *msg)
 {
+  if (msg == NULL) {
+    return;
+  }
+
   msg->data_len = 0;
 }
 

--- a/lib/bgp/parsebgp_bgp_open.c
+++ b/lib/bgp/parsebgp_bgp_open.c
@@ -210,6 +210,10 @@ void parsebgp_bgp_open_destroy(parsebgp_bgp_open_t *msg)
 
 void parsebgp_bgp_open_clear(parsebgp_bgp_open_t *msg)
 {
+  if (msg == NULL) {
+    return;
+  }
+
   msg->capabilities_cnt = 0;
 }
 

--- a/lib/bgp/parsebgp_bgp_route_refresh.c
+++ b/lib/bgp/parsebgp_bgp_route_refresh.c
@@ -76,6 +76,10 @@ void parsebgp_bgp_route_refresh_destroy(parsebgp_bgp_route_refresh_t *msg)
 
 void parsebgp_bgp_route_refresh_clear(parsebgp_bgp_route_refresh_t *msg)
 {
+  if (msg == NULL) {
+    return;
+  }
+
   msg->data_len = 0;
 }
 


### PR DESCRIPTION
Avoid crash in parsebgp_bgp_{open,notification,route_refresh}_clear() by
checking for null parameter (actually observed in parsebgp_bgp_open_clear()
after truncated message, but may have been possible in the other functions
in similar situations).