### PR TITLE
Fix parsing ipv6 addr specific extended community

### DIFF
--- a/lib/bgp/parsebgp_bgp_update_ext_communities.c
+++ b/lib/bgp/parsebgp_bgp_update_ext_communities.c
@@ -185,6 +185,7 @@ parsebgp_error_t parsebgp_bgp_update_ext_communities_ipv6_decode(
       PARSEBGP_DESERIALIZE_VAL(buf, len, nread,
                                comm->types.ip_addr.local_admin);
       comm->types.ip_addr.local_admin = ntohs(comm->types.ip_addr.local_admin);
+      break;
 
     default:
       // this is an especially unusual error


### PR DESCRIPTION
Missing `break` after parsing PARSEBGP_BGP_EXT_COMM_TYPE_*_IPV6 fell
through to not-implemented case, generating spurious error or warning
followed by misaligned parsing.
(No test case known, but the code was obviously wrong)