### PR TITLE
Add max_pfx_len param to parsebgp_decode_prefix()

### DIFF
--- a/lib/bgp/parsebgp_bgp_update.c
+++ b/lib/bgp/parsebgp_bgp_update.c
@@ -59,13 +59,14 @@ static parsebgp_error_t parse_nlris(parsebgp_bgp_update_nlris_t *nlris,
     tuple->type = PARSEBGP_BGP_PREFIX_UNICAST_IPV4;
     tuple->afi = PARSEBGP_BGP_AFI_IPV4;
     tuple->safi = PARSEBGP_BGP_SAFI_UNICAST;
+    size_t max_pfx = 32;
 
     // Read the prefix length
     PARSEBGP_DESERIALIZE_UINT8(buf, len, nread, tuple->len);
 
     // Prefix
     slen = nlris->len - nread;
-    err = parsebgp_decode_prefix(tuple->len, tuple->addr, buf, &slen);
+    err = parsebgp_decode_prefix(tuple->len, tuple->addr, buf, &slen, max_pfx);
     if (err != PARSEBGP_OK) {
       if (err == PARSEBGP_PARTIAL_MSG) {
         // decode_prefix() reached the end of the nlris, not the buffer

--- a/lib/bgp/parsebgp_bgp_update_mp_reach.c
+++ b/lib/bgp/parsebgp_bgp_update_mp_reach.c
@@ -38,12 +38,14 @@ static parsebgp_error_t parse_afi_ipv4_ipv6_nlri(
   const uint8_t *buf, size_t *lenp, size_t remain)
 {
   size_t len = *lenp, nread = 0, slen;
+  size_t max_pfx;
   uint8_t p_type = 0;
   parsebgp_bgp_prefix_t *tuple;
   parsebgp_error_t err;
 
   switch (afi) {
   case PARSEBGP_BGP_AFI_IPV4:
+    max_pfx = 32;
     switch (safi) {
     case PARSEBGP_BGP_SAFI_UNICAST:
       p_type = PARSEBGP_BGP_PREFIX_UNICAST_IPV4;
@@ -60,6 +62,7 @@ static parsebgp_error_t parse_afi_ipv4_ipv6_nlri(
     break;
 
   case PARSEBGP_BGP_AFI_IPV6:
+    max_pfx = 128;
     switch (safi) {
     case PARSEBGP_BGP_SAFI_UNICAST:
       p_type = PARSEBGP_BGP_PREFIX_UNICAST_IPV6;
@@ -97,8 +100,8 @@ static parsebgp_error_t parse_afi_ipv4_ipv6_nlri(
 
     // Prefix
     slen = len - nread;
-    if ((err = parsebgp_decode_prefix(tuple->len, tuple->addr, buf, &slen)) !=
-        PARSEBGP_OK) {
+    err = parsebgp_decode_prefix(tuple->len, tuple->addr, buf, &slen, max_pfx);
+    if (err != PARSEBGP_OK) {
       return err;
     }
     nread += slen;

--- a/lib/mrt/parsebgp_mrt.c
+++ b/lib/mrt/parsebgp_mrt.c
@@ -362,6 +362,7 @@ parse_table_dump_v2_afi_safi_rib(parsebgp_opts_t *opts,
                                  const uint8_t *buf, size_t *lenp, size_t remain)
 {
   size_t len = *lenp, nread = 0, slen;
+  size_t max_pfx;
   parsebgp_error_t err;
 
   // Sequence Number
@@ -372,8 +373,12 @@ parse_table_dump_v2_afi_safi_rib(parsebgp_opts_t *opts,
 
   // Prefix
   slen = len - nread;
-  if ((err = parsebgp_decode_prefix(msg->prefix_len, msg->prefix, buf,
-                                    &slen)) != PARSEBGP_OK) {
+  max_pfx = (subtype == PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV4_UNICAST ||
+             subtype == PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV4_MULTICAST) ?
+              32 : 128;
+  err = parsebgp_decode_prefix(msg->prefix_len, msg->prefix, buf, &slen,
+      max_pfx);
+  if (err != PARSEBGP_OK) {
     return err;
   }
   nread += slen;

--- a/lib/parsebgp_utils.c
+++ b/lib/parsebgp_utils.c
@@ -33,10 +33,11 @@
 #include <unistd.h>
 
 parsebgp_error_t parsebgp_decode_prefix(uint8_t pfx_len, uint8_t *dst,
-                                        const uint8_t *buf, size_t *buf_len)
+                                        const uint8_t *buf, size_t *buf_len,
+                                        size_t max_pfx_len)
 {
   uint8_t bytes, junk;
-  if (pfx_len > 128) {
+  if (pfx_len > max_pfx_len) {
     PARSEBGP_RETURN_INVALID_MSG_ERR;
   }
   // prefixes are encoded in a compact format the min number of bytes is used,

--- a/lib/parsebgp_utils.h
+++ b/lib/parsebgp_utils.h
@@ -272,11 +272,13 @@
  * @param buf_len       Total length of the buffer (to prevent overrun). Updated
  *                      to the number of bytes read from the buffer if
  *                      successful.
+ * @param max_pfx_len   Maximum allowed pfx_len (32 for IPv4, 128 for IPv6)
  * @return PARSEBGP_OK if successful, or an error code otherwise. buf_len is
  * only updated if PARSEBGP_OK is returned.
  */
 parsebgp_error_t parsebgp_decode_prefix(uint8_t pfx_len, uint8_t *dst,
-                                        const uint8_t *buf, size_t *buf_len);
+                                        const uint8_t *buf, size_t *buf_len,
+                                        size_t max_pfx_len);
 
 /** Convenience function to allocate and zero memory */
 void *malloc_zero(const size_t size);


### PR DESCRIPTION
Identifies an IPv4 prefix with alleged length > 32 (not 128) as invalid.