### PR TITLE
Quagga bug workaround

### DIFF
--- a/lib/mrt/parsebgp_mrt.c
+++ b/lib/mrt/parsebgp_mrt.c
@@ -701,11 +701,11 @@ static parsebgp_error_t parse_bgp4mp(parsebgp_opts_t *opts,
   // IPs in STATE_CHANGE and OPEN messages.
   // For the state change, we can easily detect this by checking the
   // subtype and length, but for OPEN, we have to peek and see if the
-  // ifindex appears to be 0xFFFF which is actually the start of the
-  // BGP marker.
+  // AFI appears to be 0xFFFF which is actually the part of the BGP
+  // marker.
   if ((subtype == PARSEBGP_MRT_BGP4MP_STATE_CHANGE && len == 8) ||
-      (subtype == PARSEBGP_MRT_BGP4MP_MESSAGE && (len - nread) > 2 &&
-       remain > 2 && (*(uint16_t *)buf) == 0xFFFF)) {
+      (subtype == PARSEBGP_MRT_BGP4MP_MESSAGE && (len - nread) > 4 &&
+       remain > 4 && memcmp(buf+2, "\xff\xff", 2) == 0)) {
     msg->interface_index = 0;
     msg->afi = 0;
     memset(msg->peer_ip, 0, sizeof(msg->peer_ip));

--- a/lib/parsebgp_utils.h
+++ b/lib/parsebgp_utils.h
@@ -256,7 +256,7 @@
 #define PARSEBGP_DUMP_IP(depth, name, afi, ipaddr)                             \
   do {                                                                         \
     int mapping[] = {-1, AF_INET, AF_INET6};                                   \
-    char ip_buf[INET6_ADDRSTRLEN];                                             \
+    char ip_buf[INET6_ADDRSTRLEN] = "[invalid IP]";                            \
     inet_ntop(mapping[afi], ipaddr, ip_buf, INET6_ADDRSTRLEN);                 \
     PARSEBGP_DUMP_INFO(depth, name ": %*s\n", 20 - (int)sizeof(name ":"),      \
                        ip_buf);                                                \
@@ -265,7 +265,7 @@
 #define PARSEBGP_DUMP_PFX(depth, name, afi, ipaddr, len)                       \
   do {                                                                         \
     int mapping[] = {-1, AF_INET, AF_INET6};                                   \
-    char ip_buf[INET6_ADDRSTRLEN];                                             \
+    char ip_buf[INET6_ADDRSTRLEN] = "[invalid IP]";                            \
     inet_ntop(mapping[afi], ipaddr, ip_buf, INET6_ADDRSTRLEN);                 \
     PARSEBGP_DUMP_INFO(depth, name ": %*s/%d\n", 20 - (int)sizeof(name ":"),   \
                        ip_buf, len);                                           \


### PR DESCRIPTION
When processing some super old (circa 2000) MRT data, I came across some records
that libparsebgp (correctly) determined were invalid, but our legacy
libbgpdump-based parser could parse them.

After checking the bgpdump code I found that they had some workarounds for a bug
in an old version of Quagga that omitted the peer information:
https://github.com/CAIDA/bgpstream/blob/master/lib/bgpdump/bgpdump_lib.c#L657
https://github.com/CAIDA/bgpstream/blob/master/lib/bgpdump/bgpdump_lib.c#L741

Example file with this type of broken data:
http://data.ris.ripe.net/rrc01/2000.11/updates.20001126.0002.gz