### PR TITLE
Separate package and shared library versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 test/*.trs
 test-driver
+lib/parsebgp.h

--- a/configure.ac
+++ b/configure.ac
@@ -26,18 +26,25 @@
 
 AC_PREREQ([2.68])
 
-AC_INIT([libparsebgp], [1.0.0], [bgpstream-info@caida.org])
 
-LIBPARSEBGP_MAJOR_VERSION=1
-LIBPARSEBGP_MID_VERSION=0
-LIBPARSEBGP_MINOR_VERSION=0
+# libparsebgp package version
+m4_define([PKG_MAJOR_VERSION], [1])
+m4_define([PKG_MID_VERSION],   [0])
+m4_define([PKG_MINOR_VERSION], [0])
 
-AC_DEFINE_UNQUOTED([LIBPARSEBGP_MAJOR_VERSION],$LIBPARSEBGP_MAJOR_VERSION,
-	[libparsebgp major version])
-AC_DEFINE_UNQUOTED([LIBPARSEBGP_MID_VERSION],$LIBPARSEBGP_MID_VERSION,
-	[libparsebgp mid version])
-AC_DEFINE_UNQUOTED([LIBPARSEBGP_MINOR_VERSION],$LIBPARSEBGP_MINOR_VERSION,
-	[libparsebgp minor version])
+AC_INIT([libparsebgp], PKG_MAJOR_VERSION.PKG_MID_VERSION.PKG_MINOR_VERSION, [bgpstream-info@caida.org])
+
+# libparsebgp shared library version
+# (no relation to pkg version)
+# see https://www.gnu.org/software/libtool/manual/html_node/Versioning.html
+# If changes break ABI compatability: CURRENT++, REVISION=0, AGE=0
+# elseif changes only add to ABI:     CURRENT++, REVISION=0, AGE++
+# else changes do not affect ABI:     REVISION++
+LIBPARSEBGP_SHLIB_CURRENT=2
+LIBPARSEBGP_SHLIB_REVISION=0
+LIBPARSEBGP_SHLIB_AGE=0
+
+######################################################################
 
 LT_INIT
 
@@ -67,12 +74,17 @@ if test x"$parser_debug" = x"yes"; then
     AC_DEFINE([PARSER_DEBUG],[],[Parser Debugging])
 fi
 
-AC_SUBST([LIBPARSEBGP_MAJOR_VERSION])
-AC_SUBST([LIBPARSEBGP_MID_VERSION])
-AC_SUBST([LIBPARSEBGP_MINOR_VERSION])
+AC_SUBST([LIBPARSEBGP_MAJOR_VERSION], PKG_MAJOR_VERSION)
+AC_SUBST([LIBPARSEBGP_MID_VERSION],   PKG_MID_VERSION)
+AC_SUBST([LIBPARSEBGP_MINOR_VERSION], PKG_MINOR_VERSION)
+
+AC_SUBST([LIBPARSEBGP_SHLIB_CURRENT])
+AC_SUBST([LIBPARSEBGP_SHLIB_REVISION])
+AC_SUBST([LIBPARSEBGP_SHLIB_AGE])
 
 AC_CONFIG_FILES([Makefile
                 lib/Makefile
+                lib/parsebgp.h
                 lib/bgp/Makefile
                 lib/bmp/Makefile
                 lib/mrt/Makefile

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -54,6 +54,6 @@ libparsebgp_la_LIBADD = 			\
 	$(top_builddir)/lib/bmp/libparsebgp_bmp.la	\
 	$(top_builddir)/lib/mrt/libparsebgp_mrt.la
 
-libparsebgp_la_LDFLAGS = -version-info @LIBPARSEBGP_MAJOR_VERSION@:@LIBPARSEBGP_MINOR_VERSION@:@LIBPARSEBGP_MID_VERSION@
+libparsebgp_la_LDFLAGS = -version-info @LIBPARSEBGP_SHLIB_CURRENT@:@LIBPARSEBGP_SHLIB_REVISION@:@LIBPARSEBGP_SHLIB_AGE@
 
 CLEANFILES = *~

--- a/lib/parsebgp.h.in
+++ b/lib/parsebgp.h.in
@@ -34,6 +34,10 @@
 #include <inttypes.h>
 #include <stddef.h>
 
+#define LIBPARSEBGP_MAJOR_VERSION @LIBPARSEBGP_MAJOR_VERSION@
+#define LIBPARSEBGP_MID_VERSION   @LIBPARSEBGP_MID_VERSION@
+#define LIBPARSEBGP_MINOR_VERSION @LIBPARSEBGP_MINOR_VERSION@
+
 /**
  * Message types supported by libparsebgp
  */


### PR DESCRIPTION
...as expected by libtool.

Add instructions on how to change shared library version.

Compile-time definition of package version is no longer in config.h, but
in parsebgp.h (which is now generated from parsebgp.h.in), so it's
available to library users.