### PR TITLE
Add option for shallow parsing of BMP messages

### DIFF
--- a/lib/bmp/parsebgp_bmp.c
+++ b/lib/bmp/parsebgp_bmp.c
@@ -1043,6 +1043,13 @@ parsebgp_error_t parsebgp_bmp_decode(parsebgp_opts_t *opts,
   slen = *len - nread;       // number of bytes left in the buffer
   remain = msg->len - nread; // number of bytes left in the message
 
+  if (opts->bmp.parse_headers_only) {
+    msg->types_valid = 0;
+    *len = msg->len;
+    return PARSEBGP_OK;
+  }
+  msg->types_valid = 1;
+
   if (remain > slen) {
     // we already know that the message will be longer than what we have in the
     // buffer, give up now
@@ -1125,6 +1132,9 @@ void parsebgp_bmp_destroy_msg(parsebgp_bmp_msg_t *msg)
 void parsebgp_bmp_clear_msg(parsebgp_bmp_msg_t *msg)
 {
   // Common header has no dynamically allocated memory
+  if (!msg->types_valid) {
+    return;
+  }
 
   switch (msg->type) {
   case PARSEBGP_BMP_TYPE_ROUTE_MON:
@@ -1162,6 +1172,10 @@ void parsebgp_bmp_dump_msg(const parsebgp_bmp_msg_t *msg, int depth)
   PARSEBGP_DUMP_STRUCT_HDR(parsebgp_bmp_msg_t, depth);
 
   dump_common_hdr(msg, depth);
+
+  if (!msg->types_valid) {
+    return;
+  }
 
   depth++;
   switch (msg->type) {

--- a/lib/bmp/parsebgp_bmp.c
+++ b/lib/bmp/parsebgp_bmp.c
@@ -1043,18 +1043,18 @@ parsebgp_error_t parsebgp_bmp_decode(parsebgp_opts_t *opts,
   slen = *len - nread;       // number of bytes left in the buffer
   remain = msg->len - nread; // number of bytes left in the message
 
+  if (remain > slen) {
+    // we already know that the message will be longer than what we have in the
+    // buffer, give up now
+    return PARSEBGP_PARTIAL_MSG;
+  }
+
   if (opts->bmp.parse_headers_only) {
     msg->types_valid = 0;
     *len = msg->len;
     return PARSEBGP_OK;
   }
   msg->types_valid = 1;
-
-  if (remain > slen) {
-    // we already know that the message will be longer than what we have in the
-    // buffer, give up now
-    return PARSEBGP_PARTIAL_MSG;
-  }
 
   switch (msg->type) {
   case PARSEBGP_BMP_TYPE_ROUTE_MON:

--- a/lib/bmp/parsebgp_bmp.h
+++ b/lib/bmp/parsebgp_bmp.h
@@ -543,6 +543,12 @@ typedef struct parsebgp_bmp_msg {
   /** Peer header (Not filled for TYPE_INIT_MSG and TYPE_TERM_MSG) */
   parsebgp_bmp_peer_hdr_t peer_hdr;
 
+  /** Set if the message was fully parsed and the types structure can
+   * be used. If this is not set, then only a shallow parse was
+   * performed, so only the common header and peer header fields have
+   * been populated. */
+  int types_valid;
+
   /** Union of structures for all supported BMP message types */
   struct {
 

--- a/lib/bmp/parsebgp_bmp_opts.h
+++ b/lib/bmp/parsebgp_bmp_opts.h
@@ -42,6 +42,17 @@ typedef struct parsebgp_bmp_opts {
    */
   parsebgp_bgp_afi_t peer_ip_afi;
 
+  /**
+   * Shallow BMP Parsing
+   *
+   * If this is set, then do not parse past the end of the peer header
+   * (or the common header in case there is no peer header).
+   *
+   * The parser will only fill the common header fields, and
+   * (possibly) the peer_hdr information.
+   */
+  int parse_headers_only;
+
 } parsebgp_bmp_opts_t;
 
 /**

--- a/tools/parsebgp.c
+++ b/tools/parsebgp.c
@@ -185,6 +185,7 @@ static void usage(void)
     "         where 'type' is one of 'bmp', 'bgp', or 'mrt'\n"
     "         (only required if using non-standard file extensions)\n"
     "       -4                 Force 4-byte ASN parsing\n"
+    "       -b                 Perform shallow BMP parsing\n"
     "       -f <attr-type>     Filter to include given Path Attribute\n"
     "       -i                 Ignore invalid messages and attributes\n"
     "                            (use multiple times to silence warnings)\n"
@@ -206,7 +207,7 @@ int main(int argc, char **argv)
   parsebgp_opts_t opts;
   parsebgp_opts_init(&opts);
 
-  while (prevoptind = optind, (opt = getopt(argc, argv, ":f:t:i4smqvh?")) >= 0) {
+  while (prevoptind = optind, (opt = getopt(argc, argv, ":f:t:i4bsmqvh?")) >= 0) {
     if (optind == prevoptind + 2 && (optarg == NULL || *optarg == '-')) {
       opt = ':';
       --optind;
@@ -214,6 +215,10 @@ int main(int argc, char **argv)
     switch (opt) {
     case '4':
       opts.bgp.asn_4_byte = 1;
+      break;
+
+    case 'b':
+      opts.bmp.parse_headers_only = 1;
       break;
 
     case 'f':


### PR DESCRIPTION
This allows users who only need header information (specifically the OpenBMP collector) to parse a BMP stream without needing to spend time fully parsing each message.