### PR TITLE
Replace an assert with an invalid message error

### DIFF
--- a/lib/bmp/parsebgp_bmp.c
+++ b/lib/bmp/parsebgp_bmp.c
@@ -1104,7 +1104,16 @@ parsebgp_error_t parsebgp_bmp_decode(parsebgp_opts_t *opts,
   }
   nread += slen;
 
-  assert(msg->len == nread);
+  if (nread != msg->len) {
+    // we didn't parse all the bytes in the BMP message (according to
+    // the length in the header).
+    // either we don't know how to parse this message fully, or there
+    // is trailing content in the BMP message.
+    assert(nread < msg->len);
+    PARSEBGP_SKIP_INVALID_MSG(opts, buf, nread, msg->len - nread,
+                              "Unparsed data at end of BMP message (%zu bytes)",
+                              msg->len - nread);
+  }
 
   *len = nread;
   return PARSEBGP_OK;


### PR DESCRIPTION
We found some messages from the new FRR codebase that seem to have trailing content included in the BMP message, but that libparsebgp does not parse (it seems that two BGP messages are included in the BMP message). We don't know the cause of this unusual message yet, but libparsebgp should not seg fault in any case.