### PR TITLE
Fix bug when parsing peer up info TLVs

### DIFF
--- a/lib/bmp/parsebgp_bmp.c
+++ b/lib/bmp/parsebgp_bmp.c
@@ -440,8 +440,10 @@ static parsebgp_error_t parse_peer_up(parsebgp_opts_t *opts,
   slen = len - nread;
   parse_info_tlvs(&msg->tlvs, &msg->_tlvs_alloc_cnt, &msg->tlvs_cnt, buf, &slen,
                   remain - nread);
+  nread += slen;
+  buf += slen;
 
-  *lenp = nread + slen;
+  *lenp = nread;
   return PARSEBGP_OK;
 }
 

--- a/lib/bmp/parsebgp_bmp.c
+++ b/lib/bmp/parsebgp_bmp.c
@@ -437,10 +437,11 @@ static parsebgp_error_t parse_peer_up(parsebgp_opts_t *opts,
   buf += slen;
 
   // Information TLVs (optional)
-  parse_info_tlvs(&msg->tlvs, &msg->_tlvs_alloc_cnt, &msg->tlvs_cnt, buf, lenp,
+  slen = len - nread;
+  parse_info_tlvs(&msg->tlvs, &msg->_tlvs_alloc_cnt, &msg->tlvs_cnt, buf, &slen,
                   remain - nread);
 
-  *lenp = nread;
+  *lenp = nread + slen;
   return PARSEBGP_OK;
 }
 


### PR DESCRIPTION
Previously we were not correctly setting the `lenp` parameter to the parse_info_tlvs function, nor correctly using the returned value in this parameter. This meant that any info TLVs would be parsed, but we did not update the number of bytes read.