### PR TITLE
Replace assert with invalid message error

### DIFF
--- a/lib/bgp/parsebgp_bgp.c
+++ b/lib/bgp/parsebgp_bgp.c
@@ -134,7 +134,9 @@ parsebgp_error_t parsebgp_bgp_decode_ext(parsebgp_opts_t *opts,
   }
   nread += slen;
 
-  assert(msg->len == nread);
+  if (msg->len != nread) {
+    PARSEBGP_RETURN_INVALID_MSG_ERR;
+  }
   *len = nread;
   return PARSEBGP_OK;
 }


### PR DESCRIPTION
We previously had an assert in place to catch parser bugs which led to not consuming the correct number of bytes from the message. This assert assumed that the message length was more trustworthy than our code. It seems that this is no longer the case. Issue #79 highlights a case where an apparently corrupted MRT file has garbage in the length field, triggering the assert. This commit replaces the assert with an invalid message error which can be handled by the user.