### PR TITLE
Fix multiple issues in handling invalid prefixes (fix #83)

### DIFF
--- a/lib/mrt/parsebgp_mrt.c
+++ b/lib/mrt/parsebgp_mrt.c
@@ -374,8 +374,14 @@ parse_table_dump_v2_afi_safi_rib(parsebgp_opts_t *opts,
              subtype == PARSEBGP_MRT_TABLE_DUMP_V2_RIB_IPV4_MULTICAST) ?
               32 : 128;
   err = parsebgp_decode_prefix(msg->prefix_len, msg->prefix, buf, &slen,
-      max_pfx);
+      max_pfx, remain - nread);
   if (err != PARSEBGP_OK) {
+    if (err == PARSEBGP_INVALID_MSG) {
+      PARSEBGP_SKIP_INVALID_MSG(opts, buf, nread, 0,
+          "%s", "Invalid prefix in rib");
+      *lenp = remain;
+      return PARSEBGP_OK;
+    }
     return err;
   }
   nread += slen;

--- a/lib/parsebgp_utils.c
+++ b/lib/parsebgp_utils.c
@@ -33,10 +33,12 @@
 
 parsebgp_error_t parsebgp_decode_prefix(uint8_t pfx_len, uint8_t *dst,
                                         const uint8_t *buf, size_t *buf_len,
-                                        size_t max_pfx_len)
+                                        size_t max_pfx_len, size_t remain)
 {
   uint8_t bytes, junk;
-  PARSEBGP_ASSERT(pfx_len <= max_pfx_len);
+  if (pfx_len > max_pfx_len) {
+    return PARSEBGP_INVALID_MSG;
+  }
   // prefixes are encoded in a compact format the min number of bytes is used,
   // so we first need to figure out how many bytes it takes to represent a
   // prefix of this length.
@@ -45,6 +47,9 @@ parsebgp_error_t parsebgp_decode_prefix(uint8_t pfx_len, uint8_t *dst,
     bytes++;
   }
   // now read the prefix
+  if (remain < bytes) {
+    return PARSEBGP_INVALID_MSG;
+  }
   if (*buf_len < bytes) {
     return PARSEBGP_PARTIAL_MSG;
   }

--- a/lib/parsebgp_utils.h
+++ b/lib/parsebgp_utils.h
@@ -301,12 +301,13 @@
  *                      to the number of bytes read from the buffer if
  *                      successful.
  * @param max_pfx_len   Maximum allowed pfx_len (32 for IPv4, 128 for IPv6)
+ * @param remain        Number of of remaining bytes in message
  * @return PARSEBGP_OK if successful, or an error code otherwise. buf_len is
  * only updated if PARSEBGP_OK is returned.
  */
 parsebgp_error_t parsebgp_decode_prefix(uint8_t pfx_len, uint8_t *dst,
                                         const uint8_t *buf, size_t *buf_len,
-                                        size_t max_pfx_len);
+                                        size_t max_pfx_len, size_t remain);
 
 /** Convenience function to allocate and zero memory */
 void *malloc_zero(const size_t size);


### PR DESCRIPTION
Properly detect and recover from an invalid prefix (invalid length for
the address family or a length that would extend past the end of the
message) in withdrawn/announced NLRI, mp_[un]reach_nlri, and
table_dump_v2 prefix, so we can use PARSEBGP_SKIP_INVALID_MSG() instead
of PARSEBGP_ASSERT().